### PR TITLE
Make horizontal navigation Project Light compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ By default the section title on the page is the site's name, to change this for 
 
 You can replace Drupal's native breadcrumbs with the [Easy breadcrumb](https://drupal.org/project/easy_breadcrumb) module. Once enabled, place the 'Easy Breadcrumb' block in the 'Breadcrumb' region.
 
+### Menu Firstchild
+
+Normally in Drupal all menu parent items have to be links, and as parent items aren't clickable in the horizontal navigation the theme will add in a child with the text of the parent plus 'overview' so that the user can get to the page. In cases where you don't want to have the parent item linking to a page, you can use the [Menu Firstchild](https://drupal.org/project/menu_firstchild) module to create a manual wrapper menu item.
+
 ### Touch Icons
 
 Drupal allows you to change the University's favicon natively, but to change the Web Clip icon for iOS devices install the [Touch Icons](https://drupal.org/project/touch_icons) module.

--- a/css/full-stylesheet.css
+++ b/css/full-stylesheet.css
@@ -1306,9 +1306,8 @@ caption{background:#fff;padding:5px 0}
 
 	.js .campl-menu-btn{margin:0;display:block;}
 
-	.campl-menu-indicator{height:48px;width:48px;position:absolute;top:0%;left:10px;display:block;margin-top:0px;border-radius:1px; -webkit-border-radius:1px;background-repeat:no-repeat;background-position:50% 50%}
-	.campl-back-link .campl-menu-indicator{height:20px;width:20px;position:absolute;top:50%;left:10px;display:block;margin-top:-10px;border-radius:1px; -webkit-border-radius:1px;background-repeat:no-repeat;background-position:50% 50%}
-	.campl-fwd-btn{right:0px;left:auto;background-image:url(../images/interface/icon-fwd-btn.png) }
+	.campl-menu-indicator{height:20px;width:20px;position:absolute;top:50%;left:10px;display:block;margin-top:-10px;border-radius:1px; -webkit-border-radius:1px;background-repeat:no-repeat;background-position:50% 50%}
+	.campl-fwd-btn{right:10px;left:auto;background-image:url(../images/interface/icon-fwd-btn.png) }
 	.campl-back-btn{left:25px;background-image:url(../images/interface/icon-back-btn.png)}
 
 	.js .campl-menu-btn span{padding:15px 0 15px 25px;display:block}
@@ -2404,4 +2403,3 @@ table th{border-bottom:#e4e4e4 1px solid}
  * z-index:15 	global header
  * z-index:16 	
 */
-

--- a/js/custom.js
+++ b/js/custom.js
@@ -495,14 +495,14 @@ projectlight.localNav=(function(){
 		
 		//Bound click event for all links inside the local navigation. 
 		//handles moving forwards and backwards through pages or opening dropdown menu
-		$links.find('span').click(function(e){
+		$links.click(function(e){
 			var $linkClicked = $(this),
-			$listItemClicked = $linkClicked.parent().parent();
+			$listItemClicked = $linkClicked.parent();
 
 			if($listItemClicked.hasClass("campl-title") && Modernizr.mq('only screen and (max-width: 767px)')){
 				e.preventDefault();
 			}else{
-				if($listItemClicked.hasClass("campl-sub") && Modernizr.mq('only screen and (max-width: 767px)')){
+				if($listItemClicked.hasClass("campl-sub")){
 					//slide mobile or tablet menu forward
 					if(projectlight.mobileLayout){
 						slideMenu("forward");
@@ -520,8 +520,8 @@ projectlight.localNav=(function(){
 				}else{
 					if($listItemClicked.hasClass("campl-back-link")){
 						slideMenu("back");
-						$linkClicked.parent().parent().parent().parent().addClass("campl-previous");
 						$linkClicked.parent().parent().parent().addClass("campl-previous");
+						$linkClicked.parent().parent().addClass("campl-previous");
 						return false
 					}
 				}

--- a/templates/menu-block-wrapper.tpl.php
+++ b/templates/menu-block-wrapper.tpl.php
@@ -22,6 +22,10 @@
           }
 
           for ($i = 1; $i < $parents_item_left; $i++) {
+            if ('<firstchild>' === $menu_trail_left[$i]['link_path']) {
+              $menu_trail_left[$i]['link_path'] = _menu_firstchild_get_firstchild_href($menu_trail_left[$i]['mlid']);
+            }
+
             $menu_trail_url = drupal_lookup_path('alias', $menu_trail_left[$i]['link_path']);
             if (FALSE === $menu_trail_url) {
               $menu_trail_url = $menu_trail_left[$i]['link_path'];
@@ -37,6 +41,10 @@
         <?php if (count($menu_trail_left) > 2 && $this_item['has_children'] == FALSE): ?>
           <li class="campl-selected">
             <?php
+
+            if ('<firstchild>' === $parent_item['link_path']) {
+              $parent_item['link_path'] = _menu_firstchild_get_firstchild_href($parent_item['mlid']);
+            }
 
             $parent_item_url = drupal_lookup_path('alias', $parent_item['link_path']);
             if (FALSE === $parent_item_url) {
@@ -56,6 +64,10 @@
           foreach ($uncles as $uncle) {
             if ($uncle->mlid == $parent_item['mlid'] || $uncle->link_title == t('Home')) {
               continue;
+            }
+
+            if ('<firstchild>' === $uncle->link_path) {
+              $uncle->link_path = _menu_firstchild_get_firstchild_href($uncle->mlid);
             }
 
             $uncle_url = drupal_lookup_path('alias', $uncle->link_path);


### PR DESCRIPTION
This fixes #14. In the horizontal navigation it adds in an extra child link with the name of the parent plus 'overview' so that it's possible to go to the pages. It also adds support for the [Menu Firstchild](https://drupal.org/project/menu_firstchild) module for cases where you don't want the extra item.
