### PR TITLE
Remove bottom padding from local tasks bar

### DIFF
--- a/template.php
+++ b/template.php
@@ -61,7 +61,7 @@ function cambridge_theme_menu_local_tasks(&$variables) {
     return NULL;
   }
 
-  $output = '<div class="campl-content-container">';
+  $output = '<div class="campl-content-container campl-no-bottom-padding">';
 
   if (!empty($variables['primary'])) {
     $variables['primary']['#prefix'] = '<h2 class="element-invisible">' . t('Primary tabs') . '</h2>';


### PR DESCRIPTION
The local tasks bar has a contain container around it, causing a large gap between it and the top of the node content:

![image](https://f.cloud.github.com/assets/1784740/2064252/0ca0a9a6-8cc8-11e3-8e29-e70ff820371c.png)

This removes the bottom padding. The only downside (though it doesn't have to be considered one) is that there is now no gap if the content doesn't have any padding at the top, such as when there's a leading image:

![image](https://f.cloud.github.com/assets/1784740/2064267/56ae672c-8cc8-11e3-9507-f4a074ad5d12.png)
