### PR TITLE
Style taxonomy term pages

### DIFF
--- a/template.php
+++ b/template.php
@@ -149,6 +149,23 @@ function cambridge_theme_left_navigation_link($variables) {
 }
 
 /**
+ * Implements template_preprocess_page().
+ */
+function cambridge_theme_preprocess_page(&$variables) {
+  if (arg(0) == 'taxonomy' && arg(1) == 'term' && is_numeric(arg(2))) {
+    // Taxonomy term listing page.
+    if (FALSE === empty($variables['page']['content']['system_main']['term_heading']['term']['#term']->description)) {
+      $variables['page']['content']['system_main']['term_heading']['#prefix'] = '<div class="campl-content-container campl-no-bottom-padding">' . $variables['page']['content']['system_main']['term_heading']['#prefix'];
+      $variables['page']['content']['system_main']['term_heading']['#suffix'] .= '<hr></div>';
+    }
+    if (isset($variables['page']['content']['system_main']['no_content'])) {
+      $variables['page']['content']['system_main']['no_content']['#prefix'] = '<div class="campl-content-container campl-no-top-padding">' . $variables['page']['content']['system_main']['no_content']['#prefix'];
+      $variables['page']['content']['system_main']['no_content']['#suffix'] .= '</div>';
+    }
+  }
+}
+
+/**
  * Implements template_preprocess_block().
  */
 function cambridge_theme_preprocess_block(&$variables) {


### PR DESCRIPTION
This adds styles so that taxonomy term pages (the description and no content message) are properly styled:

![image](https://f.cloud.github.com/assets/1784740/2195993/bd9a1dbe-98a8-11e3-84d2-d05f3ddc3f5b.png)
