### PR TITLE
Add extra horizontal nav wrapper

### DIFF
--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -274,7 +274,9 @@ $has_partnerships = isset($page['partnerships']) && count($page['partnerships'])
 
 <?php if (isset($page['horizontal_navigation'])) : ?>
   <div class="campl-row campl-page-header">
-    <?php print render($page['horizontal_navigation']); ?>
+    <div class="campl-wrap">
+      <?php print render($page['horizontal_navigation']); ?>
+    </div>
   </div>
 <?php endif; ?>
 


### PR DESCRIPTION
This fixes #33 by adding an extra `.campl-wrap` so that the contextual links menu appears within a sized container.
