### PR TITLE
Style blocks in the partnership region

### DIFF
--- a/template.php
+++ b/template.php
@@ -194,6 +194,10 @@ function cambridge_theme_preprocess_block(&$variables) {
   elseif ($variables['block']->region === 'sidebar' && $variables['block']->module !== 'views') {
     $variables['content_attributes_array']['class'][] = 'campl-content-container';
   }
+  elseif ($variables['block']->region === 'partnerships') {
+    $variables['classes_array'][] = 'campl-content-container campl-logo-container campl-bottom-padding';
+    $variables['title_attributes_array']['class'][] = 'campl-branding-title';
+  }
   elseif (in_array($variables['block']->region, array('footer_1', 'footer_2', 'footer_3', 'footer_4'))) {
     $variables['classes_array'][] = 'campl-content-container campl-navigation-list';
     $variables['theme_hook_suggestions'][] = 'block__footer_x';

--- a/templates/block--partnerships.tpl.php
+++ b/templates/block--partnerships.tpl.php
@@ -1,0 +1,15 @@
+<div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?>"<?php print $attributes; ?>>
+
+  <?php print render($title_prefix); ?>
+
+  <?php if ($block->subject): ?>
+    <p<?php print $title_attributes; ?>><?php print $block->subject ?></p>
+  <?php endif; ?>
+
+  <?php print render($title_suffix); ?>
+
+  <div<?php print $content_attributes; ?>>
+    <?php print $content ?>
+  </div>
+
+</div>


### PR DESCRIPTION
This adds styling for blocks place in the partnership branding region, so the block title becomes the caption at the top right, and the wrapper has the correct classes. The body of the block can then be manually set, or use a view to produce a list (with the correct classes attached).
