### PR TITLE
Ignore inaccessible items when finding the leading image

### DIFF
--- a/templates/node.tpl.php
+++ b/templates/node.tpl.php
@@ -16,7 +16,11 @@
   // See if the first visible item is an image field. If it is, output it outside of the campl-content-container so that
   // it appears as a leading image.
   foreach ($content as $key => $value) {
-    if (FALSE === array_key_exists('#printed', $value) || FALSE == $value['#printed']) {
+    if (
+      (FALSE === array_key_exists('#printed', $value) || FALSE == $value['#printed'])
+      &&
+      (FALSE === array_key_exists('#access', $value) || TRUE == $value['#access'])
+    ) {
       if (isset($value['#field_type']) && $value['#field_type'] === 'image') {
         print render($content[$key]);
       }


### PR DESCRIPTION
When finding the leading image (ie an image field that is the first visible item) it can currently fail if there is an inaccessible item above it (eg the language list is hidden but appears first).

This makes sure that it only looks at accessible items.
