### PR TITLE
Limit table selector

### DIFF
--- a/js/drupal.js
+++ b/js/drupal.js
@@ -29,6 +29,6 @@
 
     // Add classes to tables that are missing them and remove potentially style-breaking attributes. This should be moved to the templating layer instead.
 
-    $('table:not(.campl-table)', '.campl-content').addClass('campl-table campl-table-bordered campl-table-striped campl-vertical-stacking-table').attr('border', 0).attr('cellpadding', 0).attr('cellspacing', 0).attr('style', null);
+    $('table:not(.campl-table):not(.campl-table-custom)', '.campl-content .field').addClass('campl-table campl-table-bordered campl-table-striped campl-vertical-stacking-table').attr('border', 0).attr('cellpadding', 0).attr('cellspacing', 0).attr('style', null);
 
 })(jQuery);


### PR DESCRIPTION
Fixes #42 by limiting the selector to fields. Tables can be excluded by giving them the non-existent `campl-table-custom` class.
