### PR TITLE
Cater for modules that use strings where they should be using arrays

### DIFF
--- a/template.php
+++ b/template.php
@@ -356,6 +356,10 @@ function cambridge_theme_status_messages($variables) {
  * Implements theme_image().
  */
 function cambridge_theme_image($variables) {
+  if (isset($variables['attributes']['class']) && FALSE === is_array($variables['attributes']['class'])) {
+    $variables['attributes']['class'] = array($variables['attributes']['class']);
+  }
+
   // Make sure class is added to all images.
   $variables['attributes']['class'][] = 'campl-scale-with-grid';
 


### PR DESCRIPTION
Class attributes [should always been an array](https://drupal.org/update/modules/6/7#class_attribute_array), but some modules (such as [Image Class](https://drupal.org/node/2246595#comment-8769415)) aren't playing ball and just use strings. As we're assuming it's an array, this leads to a fatal error.

This PR makes sure that we're dealing with an array.
