### PR TITLE
Put links and comments in a container

### DIFF
--- a/css/drupal.css
+++ b/css/drupal.css
@@ -124,3 +124,8 @@
 .campl-teaser .field + .field {
     margin-top: 20px;
 }
+
+/* Prevent top margin on comment forms */
+#comments {
+    margin-top: 0;
+}

--- a/template.php
+++ b/template.php
@@ -215,6 +215,9 @@ function cambridge_theme_preprocess_block(&$variables) {
       // but it can be a form
       isset($variables['elements']['#form_id'])
       ||
+      // or a comment form
+      isset($variables['elements']['comment_form'])
+      ||
       // or a user profile
       (isset($variables['elements']['#theme']) && $variables['elements']['#theme'] === 'user_profile')
       ||

--- a/templates/node.tpl.php
+++ b/templates/node.tpl.php
@@ -9,9 +9,9 @@
   <?php print render($title_suffix); ?>
 
   <?php
-  // We hide the comments and links now so that we can render them later.
-  hide($content['comments']);
-  hide($content['links']);
+  // We render the comments and links now but show them later.
+  $comments = render($content['comments']);
+  $links = render($content['links']);
 
   // See if the first visible item is an image field. If it is, output it outside of the campl-content-container so that
   // it appears as a leading image.
@@ -44,8 +44,16 @@
     </div>
   <?php endif; ?>
 
-  <?php print render($content['links']); ?>
+  <?php if ('' !== trim($links)): ?>
+    <div class="campl-content-container campl-no-top-padding">
+      <?php print $links; ?>
+    </div>
+  <?php endif; ?>
 
-  <?php print render($content['comments']); ?>
+  <?php if ('' !== trim($comments)): ?>
+    <div class="campl-content-container campl-no-top-padding">
+      <?php print $comments; ?>
+    </div>
+  <?php endif; ?>
 
 </div>


### PR DESCRIPTION
This fixes #62 by putting links and comments blocks in a container.
