### PR TITLE
Avoid warning when no fields have content on a node

### DIFF
--- a/templates/node.tpl.php
+++ b/templates/node.tpl.php
@@ -17,9 +17,9 @@
   // it appears as a leading image.
   foreach ($content as $key => $value) {
     if (
-      (FALSE === array_key_exists('#printed', $value) || FALSE == $value['#printed'])
+      (FALSE === isset($value['#printed']) || FALSE == $value['#printed'])
       &&
-      (FALSE === array_key_exists('#access', $value) || TRUE == $value['#access'])
+      (FALSE === isset($value['#access']) || TRUE == $value['#access'])
     ) {
       if (isset($value['#field_type']) && $value['#field_type'] === 'image') {
         print render($content[$key]);


### PR DESCRIPTION
If a node has no fields (with content) for some reason, the check for the first field ends up hitting the `comment` entry which is `null` (if the Comment module is disabled) rather than an array. Using `isset()` rather than `array_key_exists()` avoids the warning.
