### PR TITLE
Theme the Views mini pager

### DIFF
--- a/template.php
+++ b/template.php
@@ -1038,6 +1038,73 @@ function cambridge_theme_pager($variables) {
 }
 
 /**
+ * Implements theme_views_mini_pager().
+ */
+function cambridge_theme_views_mini_pager($vars) {
+  global $pager_page_array, $pager_total;
+
+  $tags = $vars['tags'];
+  $element = $vars['element'];
+  $parameters = $vars['parameters'];
+
+  // current is the page we are currently paged to
+  $pager_current = $pager_page_array[$element] + 1;
+  // max is the maximum page number
+  $pager_max = $pager_total[$element];
+  // End of marker calculations.
+
+  if ($pager_total[$element] > 1) {
+
+    $li_previous = theme(
+      'pager_previous',
+      array(
+        'text' => (isset($tags[1]) ? $tags[1] : t('‹‹')),
+        'element' => $element,
+        'interval' => 1,
+        'parameters' => $parameters,
+      )
+    );
+
+    $li_next = theme(
+      'pager_next',
+      array(
+        'text' => (isset($tags[3]) ? $tags[3] : t('››')),
+        'element' => $element,
+        'interval' => 1,
+        'parameters' => $parameters,
+      )
+    );
+
+    if (!empty($li_previous)) {
+      $items[] = array('class' => array('campl-previous-li'), 'data' => $li_previous);
+    }
+
+    $items[] = array(
+      'data' => t(
+        '<span class="campl-elipsis">@current of @max</span>',
+        array('@current' => $pager_current, '@max' => $pager_max)
+      ),
+    );
+
+    if (!empty($li_next)) {
+      $items[] = array('class' => array('campl-next-li'), 'data' => $li_next);
+    }
+
+    $pagination = theme(
+      'item_list',
+      array(
+        'items' => $items,
+        'title' => NULL,
+        'type' => 'ul',
+        'attributes' => array('class' => array('pager')),
+      )
+    );
+
+    return '<div class="campl-pagination campl-pagination-centered">' . $pagination . '</div>';
+  }
+}
+
+/**
  * Implements theme_pager_previous().
  */
 function cambridge_theme_pager_previous($variables) {


### PR DESCRIPTION
Fixes #77 by theming the Views mini pager correctly:

![image](https://cloud.githubusercontent.com/assets/1784740/6230742/eed62b9a-b6b9-11e4-8b4e-f54941362020.png)

It works with Ajax, though the vertical jump that happens will be fixed by #79.