### PR TITLE
Add missing items to the page

### DIFF
--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -300,7 +300,10 @@ $has_partnerships = isset($page['partnerships']) && count($page['partnerships'])
           <img src="<?php print $logo; ?>" class="campl-co-branding-logo" alt=""/>
         <?php endif; ?>
 
-        <h1 class="campl-page-title"><?php print $site_title; ?></h1>
+        <h1 class="campl-page-title">
+          <?php print $site_title; ?>
+          <?php if (!$has_page_title): print $feed_icons; endif; ?>
+        </h1>
 
       </div>
     </div>
@@ -335,8 +338,10 @@ $has_partnerships = isset($page['partnerships']) && count($page['partnerships'])
       <?php endif; ?>
 
       <div class="<?php print $has_left_navigation ? 'campl-column9' : 'campl-column12'; ?>">
-        <div class="campl-content-container">
-          <h1 class="campl-sub-title"><?php print $title; ?></h1>
+        <div class="campl-content-container clearfix contextual-links-region">
+          <?php print render($title_prefix); ?>
+          <h1 class="campl-sub-title"><?php print $title; ?> <?php print $feed_icons; ?></h1>
+          <?php print render($title_suffix); ?>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #16, by putting the feed icon by the page title:

![image](https://cloud.githubusercontent.com/assets/1784740/6868357/f2ffc154-d482-11e4-9243-11ae93ab7e5e.png)

If the page title isn't there (usually the home page), it's placed next to the site title:

![image](https://cloud.githubusercontent.com/assets/1784740/6868378/1dad76d0-d483-11e4-85bc-d18c35cbc620.png)

This also adds in the missing prefix/suffix for the page title, to the area now has the contextual links for the page:

![image](https://cloud.githubusercontent.com/assets/1784740/6868387/258e6148-d483-11e4-9102-333df4dd448c.png)
