### PR TITLE
Make the end of active trails appear as active in menus

### DIFF
--- a/css/drupal.css
+++ b/css/drupal.css
@@ -167,3 +167,8 @@
 #comments {
     margin-top: 0;
 }
+
+/* Style faux-selected items like real ones */
+.campl-vertical-breadcrumb-navigation .campl-faux-selected > a {
+  color: #171717;
+}


### PR DESCRIPTION
A news listing page in the menu as /foo/news, then news items not in the menu as /foo/news/news-item and the Menu Trail by Path module is used, the news listing page appears as partially active in the horizontal navigation, and not at all in the vertical:

![image](https://cloud.githubusercontent.com/assets/1784740/7563677/2de361fa-f7d7-11e4-9ca2-02066d0c070c.png)

This is due to their being an active trail, but no item at the end is marked active.

This change cycles through the menu and makes then end point appear as active:

![image](https://cloud.githubusercontent.com/assets/1784740/7563678/30b2409a-f7d7-11e4-9d84-f88c14f49667.png)

The slight difference between the faux-active item and regular active items is that it is still clickable (as you're not actually on that page).