### PR TITLE
Update search.cam.ac.uk URL to be https:// instead of http://

### DIFF
--- a/templates/maintenance-page.tpl.php
+++ b/templates/maintenance-page.tpl.php
@@ -73,7 +73,7 @@ $base_theme_path = base_path() . drupal_get_path('theme', 'cambridge_theme');
         <label for="header-search" class="hidden">Search site</label>
 
         <div class="campl-search-input">
-          <form action="http://search.cam.ac.uk/web" method="get">
+          <form action="https://search.cam.ac.uk/web" method="get">
             <input id="header-search" type="text" name="query" value="" placeholder="Search"/>
 
             <input type="image" class="campl-search-submit"
@@ -87,7 +87,7 @@ $base_theme_path = base_path() . drupal_get_path('theme', 'cambridge_theme');
 </div>
 <div class="campl-row campl-global-header campl-search-drawer">
   <div class="campl-wrap clearfix">
-    <form class="campl-site-search-form" id="site-search-container" action="http://search.cam.ac.uk/web" method="get">
+    <form class="campl-site-search-form" id="site-search-container" action="https://search.cam.ac.uk/web" method="get">
       <div class="campl-search-form-wrapper clearfix">
         <input type="text" class="text" name="query" value="" placeholder="Search"/>
         <input type="image" class="campl-search-submit"

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -47,7 +47,7 @@ $has_partnerships = isset($page['partnerships']) && count($page['partnerships'])
         <label for="header-search" class="hidden">Search site</label>
 
         <div class="campl-search-input">
-          <form action="http://search.cam.ac.uk/web" method="get">
+          <form action="https://search.cam.ac.uk/web" method="get">
             <input id="header-search" type="text" name="query" value="" placeholder="Search"/>
 
             <?php
@@ -78,7 +78,7 @@ $has_partnerships = isset($page['partnerships']) && count($page['partnerships'])
 </div>
 <div class="campl-row campl-global-header campl-search-drawer">
   <div class="campl-wrap clearfix">
-    <form class="campl-site-search-form" id="site-search-container" action="http://search.cam.ac.uk/web" method="get">
+    <form class="campl-site-search-form" id="site-search-container" action="https://search.cam.ac.uk/web" method="get">
       <div class="campl-search-form-wrapper clearfix">
         <input type="text" class="text" name="query" value="" placeholder="Search"/>
 


### PR DESCRIPTION
If one's Drupal site uses https, Chrome (and possibly other browsers) refuse to
mark the page as "secure" because 'The page includes a form with a non-secure
action" attribute' - specifically, the search box. As of Chrome v62 (due for
release October 17th), using any <input> element on a http:// site will lead
to a security warning, hence PL sites may well be aiming to switch to https://
before then.