### PR TITLE
Always output alt attribute even if not set

### DIFF
--- a/template.php
+++ b/template.php
@@ -436,6 +436,11 @@ function cambridge_theme_image($variables) {
   // Make sure class is added to all images.
   $variables['attributes']['class'][] = 'campl-scale-with-grid';
 
+  // We should always output the alt attribute even if its not set
+  if (!isset($variables['alt'])) {
+    $variables['alt'] = "";
+  }
+
   return theme_image($variables);
 }
 


### PR DESCRIPTION
http://sandbox10.internal.admin.cam.ac.uk has fix applied.

If you log in you can see the data (via dpm) for the two images - the first has alt-text the second doesn't.

Previously the second would not output anything for the alt-text but it now outputs alt=""

(Note if you inspect using Safari or Chrome it will just show alt on its own - that's just a browser thing, the full alt="" is being output. This can be checked either by using Firefox or by viewing source rather than inspecting.)